### PR TITLE
Add SSE server support with configurable settings and client integrat…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 # for more detail on how to getting the api key and token please check README.md
-TRELLO_API_KEY=<your_trello_api_key>
-TRELLO_TOKEN=<your_trello_token>
+TRELLO_API_KEY=your_trello_api_key
+TRELLO_TOKEN=your_trello_token
+
+# MCP Server Configuration
+MCP_SERVER_NAME=Trello MCP Server
+MCP_SERVER_PORT=8000
+MCP_SERVER_HOST=0.0.0.0
+
+# LLM Client Configuration
+# Set to 'true' to use Claude, 'false' to use other LLMs via SSE
+# Default is true to prefer Claude app integration
+USE_CLAUDE_APP=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY pyproject.toml uv.lock ./
+RUN pip install --no-cache-dir uv && \
+    uv pip install --system -e .
+
+# Copy application code
+COPY . .
+
+# Expose port
+ENV MCP_SERVER_PORT=8000
+EXPOSE ${MCP_SERVER_PORT}
+
+# Run the application
+CMD ["python", "main.py"] 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ python main.py
 ```
 3. The server will be available at `http://localhost:8000` by default (or your configured port)
 
+### Docker Mode
+
+You can also run the server using Docker Compose:
+
+1. Make sure you have Docker and Docker Compose installed
+2. Create your `.env` file with your configuration
+3. Build and start the container:
+```bash
+docker-compose up -d
+```
+4. The server will run in SSE mode by default
+5. To view logs:
+```bash
+docker-compose logs -f
+```
+6. To stop the server:
+```bash
+docker-compose down
+```
+
 ## Configuration
 
 The server can be configured using environment variables in the `.env` file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  trello-mcp-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${MCP_SERVER_PORT:-8000}:${MCP_SERVER_PORT:-8000}"
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+      - USE_CLAUDE_APP=false  # Use SSE mode by default in Docker
+    restart: unless-stopped 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
 import os
 import logging
 import asyncio
+import uvicorn
 from dotenv import load_dotenv
+from starlette.applications import Starlette
+from starlette.routing import Mount
 from mcp.server.fastmcp import FastMCP
 from trello_server import mcp
 
@@ -15,7 +18,8 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 
-async def start_server():
+async def start_claude_server():
+    """Start the MCP server in Claude app mode"""
     try:
         # Verify environment variables
         if not os.getenv("TRELLO_API_KEY") or not os.getenv("TRELLO_TOKEN"):
@@ -23,7 +27,7 @@ async def start_server():
                 "TRELLO_API_KEY and TRELLO_TOKEN must be set in environment variables"
             )
 
-        logger.info("Starting Trello MCP Server...")
+        logger.info("Starting Trello MCP Server in Claude app mode...")
         await mcp.start()
         logger.info("Trello MCP Server started successfully")
 
@@ -31,13 +35,47 @@ async def start_server():
         while True:
             await asyncio.sleep(1)
     except Exception as e:
-        logger.error(f"Error starting server: {str(e)}")
+        logger.error(f"Error starting Claude server: {str(e)}")
+        raise
+
+
+def start_sse_server():
+    """Start the MCP server in SSE mode using uvicorn"""
+    try:
+        # Verify environment variables
+        if not os.getenv("TRELLO_API_KEY") or not os.getenv("TRELLO_TOKEN"):
+            raise ValueError(
+                "TRELLO_API_KEY and TRELLO_TOKEN must be set in environment variables"
+            )
+
+        host = os.getenv("MCP_SERVER_HOST", "0.0.0.0")
+        port = int(os.getenv("MCP_SERVER_PORT", "8000"))
+        
+        # Create Starlette app with MCP server mounted
+        app = Starlette(
+            routes=[
+                Mount("/", app=mcp.sse_app()),
+            ]
+        )
+        
+        logger.info(f"Starting Trello MCP Server in SSE mode on http://{host}:{port}...")
+        uvicorn.run(app, host=host, port=port)
+    except Exception as e:
+        logger.error(f"Error starting SSE server: {str(e)}")
         raise
 
 
 def main():
     try:
-        asyncio.run(start_server())
+        # Check which mode to run in (default to true for Claude app mode)
+        use_claude = os.getenv("USE_CLAUDE_APP", "true").lower() == "true"
+        
+        if use_claude:
+            # Run in Claude app mode
+            asyncio.run(start_claude_server())
+        else:
+            # Run in SSE mode
+            start_sse_server()
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
     except Exception as e:


### PR DESCRIPTION
# Add SSE server support with configurable settings and client integration

This pull request extends the Trello MCP server to run in both Claude app mode and SSE server mode, enabling integration with any MCP-compatible client, including Cursor, Visual Studio Code, and other tools.

## Key Features

### Dual Mode Support

- **Claude App Mode** (default): Seamless integration with Claude Desktop
  ```bash
  # Set in .env
  USE_CLAUDE_APP=true
  
  # Run with
  uv run mcp install main.py
  ```

- **SSE Server Mode**: Universal client support
  ```bash
  # Set in .env
  USE_CLAUDE_APP=false
  MCP_SERVER_PORT=8000
  MCP_SERVER_HOST=0.0.0.0
  
  # Run with
  python main.py
  ```

### Client Integration Examples

- **Cursor**: Add to `~/.cursor/mcp.json`
  ```json
  {
    "mcpServers": {
      "trello": {
        "url": "http://localhost:8000/sse"
      }
    }
  }
  ```

- **Python Client**: Simple connectivity example
  ```python
  import asyncio
  import httpx

  async def connect_to_mcp_server():
      url = "http://localhost:8000/sse"
      headers = {"Accept": "text/event-stream"}
      
      async with httpx.AsyncClient() as client:
          async with client.stream("GET", url, headers=headers) as response:
              # Process SSE messages...
  ```

## Benefits

- Broader accessibility for Trello integration
- Configurable host/port settings
- Backward compatible (Claude app mode remains default)
- Improved documentation with examples

This enhancement maintains all existing functionality while adding new capabilities for different user environments and tooling ecosystems.