### PR TITLE
fix: updating card with nested kwargs causes slient API errors

### DIFF
--- a/server/dtos/update_card.py
+++ b/server/dtos/update_card.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+
+
+class UpdateCardPayload(BaseModel):
+    """
+    Payload for updating a card.
+
+    Attributes:
+        name (str): The name of the card.
+        desc (str): The description of the card.
+        pos (str | int): The position of the card.
+        closed (bool): Whether the card is closed or not.
+        due (str): The due date of the card in ISO 8601 format.
+    """
+
+    name: str | None = None
+    desc: str | None = None
+    pos: str | None = None
+    closed: bool | None = None
+    due: str | None = None

--- a/server/tools/card.py
+++ b/server/tools/card.py
@@ -10,6 +10,7 @@ from mcp.server.fastmcp import Context
 from server.models import TrelloCard
 from server.services.card import CardService
 from server.trello import client
+from server.dtos.update_card import UpdateCardPayload
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,9 @@ async def create_card(
         raise
 
 
-async def update_card(ctx: Context, card_id: str, **kwargs) -> TrelloCard:
+async def update_card(
+    ctx: Context, card_id: str, payload: UpdateCardPayload
+) -> TrelloCard:
     """Updates a card's attributes.
 
     Args:
@@ -94,8 +97,10 @@ async def update_card(ctx: Context, card_id: str, **kwargs) -> TrelloCard:
         TrelloCard: The updated card object.
     """
     try:
-        logger.info(f"Updating card {card_id} with attributes: {kwargs}")
-        result = await service.update_card(card_id, **kwargs)
+        logger.info(f"Updating card: {card_id} with payload: {payload}")
+        result = await service.update_card(
+            card_id, **payload.model_dump(exclude_unset=True)
+        )
         logger.info(f"Successfully updated card: {card_id}")
         return result
     except Exception as e:


### PR DESCRIPTION
This PR fixes the issue when updating a card with any 
Passing the `kwargs` to the API client converts it to a nested structure:
```python
{"kwargs": {"desc": "Lorem Ipsum"}}
```
This payload is then ignored by the Trello API and returned `200 OK` without errors.

With this PR, it users can pass name, description, position, closed and due arguments. They will then converted to flat dict via pydantic. 