### PR TITLE
feat: added move_card function

### DIFF
--- a/server/services/card.py
+++ b/server/services/card.py
@@ -82,3 +82,20 @@ class CardService:
             Dict[str, Any]: The response from the delete operation.
         """
         return await self.client.DELETE(f"/cards/{card_id}")
+
+    async def move_card(self, card_id: str, list_id: str, pos: str | None = None) -> TrelloCard:
+        """Moves a card to a different list.
+
+        Args:
+            card_id (str): The ID of the card to move.
+            list_id (str): The ID of the list to move the card to.
+            pos (str, optional): The position of the card in the new list (top, bottom, or a positive number). Defaults to None.
+
+        Returns:
+            TrelloCard: The updated card object.
+        """
+        data = {"idList": list_id}
+        if pos:
+            data["pos"] = pos
+        response = await self.client.PUT(f"/cards/{card_id}", data=data)
+        return TrelloCard(**response)

--- a/server/tools/card.py
+++ b/server/tools/card.py
@@ -129,3 +129,28 @@ async def delete_card(ctx: Context, card_id: str) -> dict:
         logger.error(error_msg)
         await ctx.error(error_msg)
         raise
+
+
+async def move_card(
+    ctx: Context, card_id: str, list_id: str, pos: str | None = None
+) -> TrelloCard:
+    """Moves a card to a different list.
+
+    Args:
+        card_id (str): The ID of the card to move.
+        list_id (str): The ID of the list to move the card to.
+        pos (str, optional): The position of the card in the new list (top, bottom, or a positive number). Defaults to None.
+
+    Returns:
+        TrelloCard: The moved card object.
+    """
+    try:
+        logger.info(f"Moving card {card_id} to list {list_id} at position: {pos}")
+        result = await service.move_card(card_id, list_id, pos)
+        logger.info(f"Successfully moved card {card_id} to list {list_id}")
+        return result
+    except Exception as e:
+        error_msg = f"Failed to move card: {str(e)}"
+        logger.error(error_msg)
+        await ctx.error(error_msg)
+        raise

--- a/server/tools/tools.py
+++ b/server/tools/tools.py
@@ -24,6 +24,7 @@ def register_tools(mcp):
     mcp.add_tool(card.create_card)
     mcp.add_tool(card.update_card)
     mcp.add_tool(card.delete_card)
+    mcp.add_tool(card.move_card)
 
     # Checklist Tools
     mcp.add_tool(checklist.get_checklist)


### PR DESCRIPTION
## Purpose
This pull request introduces the functionality to move Trello cards between different lists, enhancing the card management capabilities within the MCP server.

## Summary
- Added `move_card` functionality to allow moving cards between lists.
- Implemented in the service layer (`CardService`) and as an MCP tool.
- Supports an optional `position` parameter for placing the card at the "top", "bottom", or a specific numeric position within the target list.

## Changes
- Added `move_card` method to `CardService` in `server/services/card.py`.
- Created an MCP tool for the `move_card` operation in `server/tools/card.py`.
- Registered the new `move_card` tool in `server/tools/tools.py`.
- The new service method utilizes existing Trello API communication capabilities in `server/utils/trello_api.py` (e.g., the generic PUT request handler).

## Usage
The new `move_card` tool allows moving a Trello card to a different list with optional positioning:

- `card_id` (str): The ID of the card to be moved.
- `target_list_id` (str): The ID of the destination list.
- `position` (str, optional): The desired position in the target list. Can be "top", "bottom", or a positive numeric value. Defaults to "top" if not provided.
