### PR TITLE
Add dueCompleted field support

### DIFF
--- a/server/dtos/update_card.py
+++ b/server/dtos/update_card.py
@@ -11,6 +11,7 @@ class UpdateCardPayload(BaseModel):
         pos (str | int): The position of the card.
         closed (bool): Whether the card is closed or not.
         due (str): The due date of the card in ISO 8601 format.
+        dueComplete (bool): Whether the due date is marked as complete.
         idLabels (str): Comma-separated list of label IDs for the card.
     """
 
@@ -19,4 +20,5 @@ class UpdateCardPayload(BaseModel):
     pos: str | None = None
     closed: bool | None = None
     due: str | None = None
+    dueComplete: bool | None = None
     idLabels: str | None = None

--- a/server/models.py
+++ b/server/models.py
@@ -45,3 +45,4 @@ class TrelloCard(BaseModel):
     pos: float
     labels: List[TrelloLabel] = []
     due: Optional[str] = None
+    dueComplete: bool = False


### PR DESCRIPTION
## Add dueComplete field support

This PR adds support for the `dueComplete` field in card updates, allowing users to mark tasks as completed directly through the API.

### Changes:
- Added `dueComplete` field to `UpdateCardPayload` model
- Added `dueComplete` to `TrelloCard` model

### Testing:
- [x] Field accepts boolean values
- [x] Card completion status updates correctly
- [x] No breaking changes to existing functionality