### PR TITLE
Code style improvements and modernization

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from pydantic import BaseModel
 
@@ -8,9 +8,9 @@ class TrelloBoard(BaseModel):
 
     id: str
     name: str
-    desc: Optional[str] = None
+    desc: str | None = None
     closed: bool = False
-    idOrganization: Optional[str] = None
+    idOrganization: str | None = None
     url: str
 
 
@@ -29,7 +29,7 @@ class TrelloLabel(BaseModel):
     
     id: str
     name: str
-    color: Optional[str] = None
+    color: str | None = None
 
 
 class TrelloCard(BaseModel):
@@ -37,11 +37,11 @@ class TrelloCard(BaseModel):
 
     id: str
     name: str
-    desc: Optional[str] = None
+    desc: str | None = None
     closed: bool = False
     idList: str
     idBoard: str
     url: str
     pos: float
     labels: List[TrelloLabel] = []
-    due: Optional[str] = None
+    due: str | None = None

--- a/server/services/checklist.py
+++ b/server/services/checklist.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from server.utils.trello_api import TrelloClient
 
@@ -39,7 +39,7 @@ class ChecklistService:
         return await self.client.GET(f"/cards/{card_id}/checklists")
 
     async def create_checklist(
-        self, card_id: str, name: str, pos: Optional[str] = None
+        self, card_id: str, name: str, pos: str | None = None
     ) -> Dict:
         """
         Create a new checklist on a card.
@@ -58,7 +58,7 @@ class ChecklistService:
         return await self.client.POST(f"/checklists", data={"idCard": card_id, **data})
 
     async def update_checklist(
-        self, checklist_id: str, name: Optional[str] = None, pos: Optional[str] = None
+        self, checklist_id: str, name: str | None = None, pos: str | None = None
     ) -> Dict:
         """
         Update an existing checklist.
@@ -95,7 +95,7 @@ class ChecklistService:
         checklist_id: str,
         name: str,
         checked: bool = False,
-        pos: Optional[str] = None,
+        pos: str | None = None,
     ) -> Dict:
         """
         Add a new item to a checklist.
@@ -120,9 +120,9 @@ class ChecklistService:
         self,
         checklist_id: str,
         checkitem_id: str,
-        name: Optional[str] = None,
-        checked: Optional[bool] = None,
-        pos: Optional[str] = None,
+        name: str | None = None,
+        checked: bool | None = None,
+        pos: str | None = None,
     ) -> Dict:
         """
         Update a checkitem in a checklist.

--- a/server/tools/checklist.py
+++ b/server/tools/checklist.py
@@ -3,7 +3,7 @@ This module contains tools for managing Trello checklists.
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from server.services.checklist import ChecklistService
 from server.trello import client
@@ -38,7 +38,7 @@ async def get_card_checklists(card_id: str) -> List[Dict]:
     return await service.get_card_checklists(card_id)
 
 
-async def create_checklist(card_id: str, name: str, pos: Optional[str] = None) -> Dict:
+async def create_checklist(card_id: str, name: str, pos: str | None = None) -> Dict:
     """
     Create a new checklist on a card.
 
@@ -54,7 +54,7 @@ async def create_checklist(card_id: str, name: str, pos: Optional[str] = None) -
 
 
 async def update_checklist(
-    checklist_id: str, name: Optional[str] = None, pos: Optional[str] = None
+    checklist_id: str, name: str | None = None, pos: str | None = None
 ) -> Dict:
     """
     Update an existing checklist.
@@ -84,7 +84,7 @@ async def delete_checklist(checklist_id: str) -> Dict:
 
 
 async def add_checkitem(
-    checklist_id: str, name: str, checked: bool = False, pos: Optional[str] = None
+    checklist_id: str, name: str, checked: bool = False, pos: str | None = None
 ) -> Dict:
     """
     Add a new item to a checklist.
@@ -104,9 +104,9 @@ async def add_checkitem(
 async def update_checkitem(
     checklist_id: str,
     checkitem_id: str,
-    name: Optional[str] = None,
-    checked: Optional[bool] = None,
-    pos: Optional[str] = None,
+    name: str | None = None,
+    checked: bool | None = None,
+    pos: str | None = None,
 ) -> Dict:
     """
     Update a checkitem in a checklist.


### PR DESCRIPTION
## Fix type annotation inconsistency

This PR fixes inconsistent type annotation syntax by standardizing on the modern `Type | None` format throughout the codebase.

### Problem:
Recent PRs introduced `Optional[Type]` syntax in some places, while the rest of the codebase uses `Type | None`. This creates inconsistency.

### Changes:
- Replace remaining `Optional[Type]` with `Type | None` syntax
- Standardize type annotations to match the existing codebase style
- Maintain consistency with the project's established patterns

### Examples:
```python
# Inconsistent
idOrganization: Optional[str] = None

# Consistent with the existing codebase
idOrganization: str | None = None