### PR TITLE
feat: put most used fields into update card payload

### DIFF
--- a/server/dtos/update_card.py
+++ b/server/dtos/update_card.py
@@ -8,15 +8,27 @@ class UpdateCardPayload(BaseModel):
     Attributes:
         name (str): The name of the card.
         desc (str): The description of the card.
-        pos (str | int): The position of the card.
         closed (bool): Whether the card is closed or not.
-        due (str): The due date of the card in ISO 8601 format.
+        idMembers (str): Comma-separated list of member IDs for the card.
+        idList (str): The ID of the list the card is in.
         idLabels (str): Comma-separated list of label IDs for the card.
+        idBoard (str): The ID of the board the card is in.
+        pos (str | int): The position of the card.
+        due (str): The due date of the card in ISO 8601 format.
+        start (str): The start date of the card in ISO 8601 format.
+        dueComplete (bool): Whether the card is due complete or not.
+        subscribed (bool): Whether the card is subscribed or not.
     """
 
     name: str | None = None
     desc: str | None = None
-    pos: str | None = None
     closed: bool | None = None
-    due: str | None = None
+    idMembers: str | None = None
+    idList: str | None = None
     idLabels: str | None = None
+    idBoard: str | None = None
+    pos: str | None = None
+    due: str | None = None
+    start: str | None = None
+    dueComplete: bool | None = None
+    subscribed: bool | None = None


### PR DESCRIPTION
This small PR extends the update card payload model, in doer to send request with idList, idMemebers etc. of a card to update via API