### PR TITLE
feat: payload model for create card requests

### DIFF
--- a/server/dtos/create_card.py
+++ b/server/dtos/create_card.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel
+
+
+class CreateCardPayload(BaseModel):
+    """
+    Payload for creating a card.
+
+    Attributes:
+        name (str): The name of the card.
+        desc (str): The description of the card.
+        closed (bool): Whether the card is closed or not.
+        idMembers (str): Comma-separated list of member IDs for the card.
+        idList (str): The ID of the list the card is in.
+        idLabels (str): Comma-separated list of label IDs for the card.
+        idBoard (str): The ID of the board the card is in.
+        pos (str | int): The position of the card.
+        due (str): The due date of the card in ISO 8601 format.
+        start (str): The start date of the card in ISO 8601 format.
+        dueComplete (bool): Whether the card is due complete or not.
+        subscribed (bool): Whether the card is subscribed or not.
+    """
+
+    name: str
+    desc: str | None = None
+    closed: bool | None = None
+    idMembers: str | None = None
+    idList: str
+    idLabels: str | None = None
+    idBoard: str | None = None
+    pos: str | None = None
+    due: str | None = None
+    start: str | None = None
+    dueComplete: bool | None = None
+    subscribed: bool | None = None

--- a/server/services/card.py
+++ b/server/services/card.py
@@ -40,12 +40,10 @@ class CardService:
         response = await self.client.GET(f"/lists/{list_id}/cards")
         return [TrelloCard(**card) for card in response]
 
-    async def create_card(
-        self, list_id: str, name: str, desc: str | None = None
-    ) -> TrelloCard:
+    async def create_card(self, **kwargs) -> TrelloCard:
         """Creates a new card in a given list.
 
-        Args:
+        Args
             list_id (str): The ID of the list to create the card in.
             name (str): The name of the new card.
             desc (str, optional): The description of the new card. Defaults to None.
@@ -53,10 +51,7 @@ class CardService:
         Returns:
             TrelloCard: The newly created card object.
         """
-        data = {"name": name, "idList": list_id}
-        if desc:
-            data["desc"] = desc
-        response = await self.client.POST("/cards", data=data)
+        response = await self.client.POST("/cards", data=kwargs)
         return TrelloCard(**response)
 
     async def update_card(self, card_id: str, **kwargs) -> TrelloCard:

--- a/server/tools/card.py
+++ b/server/tools/card.py
@@ -11,6 +11,7 @@ from server.models import TrelloCard
 from server.services.card import CardService
 from server.trello import client
 from server.dtos.update_card import UpdateCardPayload
+from server.dtos.create_card import CreateCardPayload
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +60,7 @@ async def get_cards(ctx: Context, list_id: str) -> List[TrelloCard]:
         raise
 
 
-async def create_card(
-    ctx: Context, list_id: str, name: str, desc: str | None = None
-) -> TrelloCard:
+async def create_card(ctx: Context, payload: CreateCardPayload) -> TrelloCard:
     """Creates a new card in a given list.
 
     Args:
@@ -73,9 +72,9 @@ async def create_card(
         TrelloCard: The newly created card object.
     """
     try:
-        logger.info(f"Creating card in list {list_id} with name: {name}")
-        result = await service.create_card(list_id, name, desc)
-        logger.info(f"Successfully created card in list: {list_id}")
+        logger.info(f"Creating card in list {payload.idList} with name: {payload.name}")
+        result = await service.create_card(**payload.model_dump(exclude_unset=True))
+        logger.info(f"Successfully created card in list: {payload.idList}")
         return result
     except Exception as e:
         error_msg = f"Failed to create card: {str(e)}"


### PR DESCRIPTION
This pull request refactors the card creation process in the backend by introducing a new `CreateCardPayload` data model and updating related methods to use this model. The changes improve code clarity, reduce duplication, and make the API more flexible.

### Introduction of `CreateCardPayload` model:
* [`server/dtos/create_card.py`](diffhunk://#diff-b74d683eba6888712317e81ba1656d6ae02f72778c021febea6fbf763a97e7f8R1-R34): Added a new `CreateCardPayload` class using Pydantic to define the structure and validation rules for card creation payloads. This includes attributes such as `name`, `desc`, `idList`, and others.

### Refactoring card creation logic:
* [`server/services/card.py`](diffhunk://#diff-d85adca0f8108ade6e6973af7724cfce19ede44e30ede826da5c21ca6e4e98b0L43-R54): Updated the `create_card` method in the `CardService` class to accept keyword arguments (`**kwargs`) instead of individual parameters, allowing it to work seamlessly with the `CreateCardPayload` model.
* [`server/tools/card.py`](diffhunk://#diff-06d156e5ff2b9a2fcd8e5b07dc05dba6b2017da3f258fe2086bc0aadec678affR14): Updated the `create_card` function to accept a `CreateCardPayload` object instead of separate parameters. The payload is passed to the service layer using the `model_dump` method to exclude unset fields. Logging statements were updated to reflect the new structure. [[1]](diffhunk://#diff-06d156e5ff2b9a2fcd8e5b07dc05dba6b2017da3f258fe2086bc0aadec678affR14) [[2]](diffhunk://#diff-06d156e5ff2b9a2fcd8e5b07dc05dba6b2017da3f258fe2086bc0aadec678affL62-R63) [[3]](diffhunk://#diff-06d156e5ff2b9a2fcd8e5b07dc05dba6b2017da3f258fe2086bc0aadec678affL76-R77)