### PR TITLE
feat: updated readme and linted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # Trello MCP Server
 
-A powerful MCP server for interacting with Trello boards, lists, and cards via AI Hosts.
-It was designed for use with **Claude Desktop**, but also supports other clients via **SSE server mode**.
+A powerful MCP server for interacting with Trello boards, lists, and cards via
+AI Hosts.
+It was designed for use with **Claude Desktop**, but also supports other clients
+via **SSE server mode**.
 
 ## Table of Contents
+
 - [Table of Contents](#table-of-contents)
 - [Prerequisites](#prerequisites)
-- [Pre-installation](#pre-installation)
-- [Installation](#installation)
-- [Server Modes](#server-modes)
+- [Installation for Claude Desktop mode](#installation-for-claude-desktop-mode)
+- [Installation for SSE server mode](#installation-for-sse-server-mode)
 - [Configuration](#configuration)
-- [Client Integration](#client-integration)
 - [Capabilities](#capabilities)
 - [Detailed Capabilities](#detailed-capabilities)
-    - [Board Operations](#board-operations)
-    - [List Operations](#list-operations)
-    - [Card Operations](#card-operations)
+  - [Board Operations](#board-operations)
+  - [List Operations](#list-operations)
+  - [Card Operations](#card-operations)
 - [Usage](#usage)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
-
 
 ## Prerequisites
 
@@ -28,31 +28,34 @@ It was designed for use with **Claude Desktop**, but also supports other clients
 - [Claude for Desktop](https://claude.ai/download) installed
 - You have already logged in with your account into Claude
 - A git client, so you can clone this repository
-- [uv](https://docs.astral.sh/uv/#installation) to run python. It manages python versions and dependencies too.
+- [uv](https://docs.astral.sh/uv/#installation) to run python. It manages python
+  versions and dependencies too.
 - Trello account, so you can get API credentials (later in this guide)
 
 ### SSE server mode
 
 - A git client, so you can clone this repository
 - [Docker](https://www.docker.com/) to run the server with docker
-- or [uv](https://docs.astral.sh/uv/#installation) to run the server with python if you donøt want to use docker
+- or [uv](https://docs.astral.sh/uv/#installation) to run the server with python
+  if you don't want to use docker
 
 ## Installation for Claude Desktop mode
 
 First, set up Trello API credentials:
 
 - Go to [Trello Apps Administration](https://trello.com/power-ups/admin)
-- Create a new integration at [New Power-Up or Integration](https://trello.com/power-ups/admin/new)
-- Fill in your information (you can leave the Iframe connector URL empty) and make sure to select the correct Workspace
+- Create a new integration at
+  [New Power-Up or Integration](https://trello.com/power-ups/admin/new)
+- Fill in your information (you can leave the Iframe connector URL empty) and
+  make sure to select the correct Workspace
 - Click your app's icon and navigate to "API key" from left sidebar
-    - **NOTE**: The secret you see on that screen is **NOT** your token
+  - **NOTE**: The secret you see on that screen is **NOT** your token
 - Copy your "API key" and store it safely, you will need it later
-- On the right side, hidden in the text: "you can manually generate a Token." 
-    - Click the word "Token" to get af form to fill out for your Trello Token 
+- On the right side, hidden in the text: "you can manually generate a Token."
+  - Click the word "Token" to get af form to fill out for your Trello Token
 - Fill out the form and then click next
 
 - You will now get your Token. Store it safely, you will need it later
-
 
 Then, clone this repository:
 
@@ -61,7 +64,8 @@ git clone https://github.com/m0xai/trello-mcp-server.git
 cd trello-mcp-server
 ```
 
-Then, Rename the `.env.example` file in the project root with `.env` and set the TRELLO_... variables you just got:
+Then, Rename the `.env.example` file in the project root with `.env` and set the
+TRELLO\_... variables you just got:
 
 ```bash
 TRELLO_API_KEY=your_api_key_here
@@ -69,10 +73,14 @@ TRELLO_TOKEN=your_token_here
 ```
 
 Then, Install uv if you haven't already:
+
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
-Then, use uv to get pythonm install dependencies and install the server for Claude using uv:
+
+Then, use uv to get pythonm install dependencies and install the server for
+Claude using uv:
+
 ```bash
 uv run mcp install main.py
 ```
@@ -80,17 +88,19 @@ uv run mcp install main.py
 Finally, **restart** Claude Desktop app.
 It should be ready to use. Try asking it to summarize a Trello card.
 
-
 ## Installation for SSE server mode
 
-This mode runs as a standalone SSE server that can be used with any MCP-compatible client, including Cursor.
-The server will be available at `http://localhost:8000/sse` by default (or change the port by modifying MCP_SERVER_PORT in your .env file)
+This mode runs as a standalone SSE server that can be used with any
+MCP-compatible client, including Cursor.
+The server will be available at `http://localhost:8000/sse` by default (or
+change the port by modifying MCP_SERVER_PORT in your .env file)
 
 You can run with docker or python (using uv)
 
 ### Run with Docker
 
-You can choose to run with Docker (then you don't need python and uv)), if you run this command: 
+You can choose to run with Docker (then you don't need python and uv)), if you
+run this command:
 
 ```bash
 docker compose up -d
@@ -110,20 +120,24 @@ docker compose down
 
 ### Run with Python and 'uv'
 
-As an alternative, you can choose to run with python (then you don't need docker)), if you run this command: 
+As an alternative, you can choose to run with python (then you don't need
+docker)), if you run this command:
 
 ```bash
 USE_CLAUDE_APP=false uv run main.py
 ```
 
-### Client Integration for SSE mode, Using with Cursor
+### Client Integration for SSE mode, using with Cursor
 
 To connect your MCP server to Cursor:
-2. In Cursor, go to Settings (gear icon) > AI > Model Context Protocol
-3. Add a new server with URL `http://localhost:8000/sse` (or your configured host/port)
-4. Select the server when using Cursor's AI features
 
-You can also add this configuration to your Cursor settings JSON file (typically at `~/.cursor/mcp.json`):
+1. In Cursor, go to Settings (gear icon) > AI > Model Context Protocol
+2. Add a new server with URL `http://localhost:8000/sse` (or your configured
+   host/port)
+3. Select the server when using Cursor's AI features
+
+You can also add this configuration to your Cursor settings JSON file (typically
+at `~/.cursor/mcp.json`):
 
 ```json
 {
@@ -137,7 +151,8 @@ You can also add this configuration to your Cursor settings JSON file (typically
 
 ### Using with Other MCP Clients
 
-For other MCP-compatible clients, point them to the SSE endpoint at `http://localhost:8000/sse`.
+For other MCP-compatible clients, point them to the SSE endpoint at
+`http://localhost:8000/sse`.
 
 ### Minimal Client Example
 
@@ -150,7 +165,7 @@ import httpx
 async def connect_to_mcp_server():
     url = "http://localhost:8000/sse"
     headers = {"Accept": "text/event-stream"}
-    
+
     async with httpx.AsyncClient() as client:
         async with client.stream("GET", url, headers=headers) as response:
             # Get the session ID from the first SSE message
@@ -160,7 +175,7 @@ async def connect_to_mcp_server():
                     data = line[5:].strip()
                     if "session_id=" in data and not session_id:
                         session_id = data.split("session_id=")[1]
-                        
+
                         # Send a message using the session ID
                         message_url = f"http://localhost:8000/messages/?session_id={session_id}"
                         message = {
@@ -180,33 +195,35 @@ if __name__ == "__main__":
 
 The server can be configured using environment variables in the `.env` file:
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| TRELLO_API_KEY | Your Trello API key | Required |
-| TRELLO_TOKEN | Your Trello API token | Required |
-| MCP_SERVER_NAME | The name of the MCP server | Trello MCP Server |
-| MCP_SERVER_HOST | Host address for SSE mode | 0.0.0.0 |
-| MCP_SERVER_PORT | Port for SSE mode | 8000 |
-| USE_CLAUDE_APP | Whether to use Claude app mode | true |
+| Variable        | Description                    | Default           |
+| --------------- | ------------------------------ | ----------------- |
+| TRELLO_API_KEY  | Your Trello API key            | Required          |
+| TRELLO_TOKEN    | Your Trello API token          | Required          |
+| MCP_SERVER_NAME | The name of the MCP server     | Trello MCP Server |
+| MCP_SERVER_HOST | Host address for SSE mode      | 0.0.0.0           |
+| MCP_SERVER_PORT | Port for SSE mode              | 8000              |
+| USE_CLAUDE_APP  | Whether to use Claude app mode | true              |
 
 You can customize the server by editing these values in your `.env` file.
 
 ## Capabilities
 
 | Operation | Board | List | Card | Checklist | Checklist Item |
-|-----------|-------|------|------|-----------|----------------|
-| Read      | ✅    | ✅    | ✅   | ✅        | ✅              |
-| Write     | ❌    | ✅    | ✅   | ✅        | ✅              |
-| Update    | ❌    | ✅    | ✅   | ✅        | ✅              |
-| Delete    | ❌    | ✅    | ✅   | ✅        | ✅              |
+| --------- | ----- | ---- | ---- | --------- | -------------- |
+| Read      | ✅    | ✅   | ✅   | ✅        | ✅             |
+| Write     | ❌    | ✅   | ✅   | ✅        | ✅             |
+| Update    | ❌    | ✅   | ✅   | ✅        | ✅             |
+| Delete    | ❌    | ✅   | ✅   | ✅        | ✅             |
 
 ### Detailed Capabilities
 
 #### Board Operations
+
 - ✅ Read all boards
 - ✅ Read specific board details
 
 #### List Operations
+
 - ✅ Read all lists in a board
 - ✅ Read specific list details
 - ✅ Create new lists
@@ -214,6 +231,7 @@ You can customize the server by editing these values in your `.env` file.
 - ✅ Archive (delete) lists
 
 #### Card Operations
+
 - ✅ Read all cards in a list
 - ✅ Read specific card details
 - ✅ Create new cards
@@ -221,6 +239,7 @@ You can customize the server by editing these values in your `.env` file.
 - ✅ Delete cards
 
 #### Checklist Operations
+
 - ✅ Get a specific checklist
 - ✅ List all checklists in a card
 - ✅ Create a new checklist
@@ -232,7 +251,8 @@ You can customize the server by editing these values in your `.env` file.
 
 ## Usage
 
-Once installed, you can interact with your Trello boards through Claude. Here are some example queries:
+Once installed, you can interact with your Trello boards through Claude. Here
+are some example queries:
 
 - "Show me all my boards"
 - "What lists are in board [board_name]?"
@@ -242,11 +262,11 @@ Once installed, you can interact with your Trello boards through Claude. Here ar
 
 Here are my example usages:
 
-<img width="1277" alt="Example Usage of Trello MCP server: Asking to list all my cards in Guitar Board" src="https://github.com/user-attachments/assets/fef29dfc-04b2-4af9-92a6-f8db2320c860" />
+![Example Usage of Trello MCP server: Asking to list all my cards in Guitar Board](https://github.com/user-attachments/assets/fef29dfc-04b2-4af9-92a6-f8db2320c860)
 
-<img width="1274" alt="Asking to add new song card into my project songs" src="https://github.com/user-attachments/assets/2d8406ca-1dde-41c0-a035-86d5271dd78f" />
+![Asking to add new song card into my project songs](https://github.com/user-attachments/assets/2d8406ca-1dde-41c0-a035-86d5271dd78f)
 
-<img width="1632" alt="Asking to add new card with checklist in it" src="https://github.com/user-attachments/assets/5a63f107-d135-402d-ab33-b9bf13eca751" />
+![Asking to add new card with checklist in it](https://github.com/user-attachments/assets/5a63f107-d135-402d-ab33-b9bf13eca751)
 
 ## Troubleshooting
 


### PR DESCRIPTION
Hi m0xai,

I've been using the trello-mcp-server for a few days and I really like it. 
During installation and use, I noticed that the readme could use a little upgrade. 
I've rewritten parts of the readme and also ran a markdown linter and fixed whatever it founds

This is the linter I ran:
docker run --rm --volume ".:/wrk" -w '/wrk' thegeeklab/markdownlint-cli:latest .

I hope you like my suggestions