### PR TITLE
fix: use card checkItem endpoint when updating checkitems

### DIFF
--- a/server/services/checklist.py
+++ b/server/services/checklist.py
@@ -137,15 +137,18 @@ class ChecklistService:
         Returns:
             Dict: The updated checkitem data
         """
+        checklist = await self.get_checklist(checklist_id)
+        card_id = checklist["idCard"]
+
         data = {}
         if name:
             data["name"] = name
         if checked is not None:
-            data["checked"] = checked
+            data["state"] = "complete" if checked else "incomplete"
         if pos:
             data["pos"] = pos
         return await self.client.PUT(
-            f"/checklists/{checklist_id}/checkItems/{checkitem_id}", data=data
+            f"/cards/{card_id}/checkItem/{checkitem_id}", data=data
         )
 
     async def delete_checkitem(self, checklist_id: str, checkitem_id: str) -> Dict:


### PR DESCRIPTION
## Summary
- Fix `update_checkitem` to use Trello's `/cards/{cardId}/checkItem/{id}` endpoint
- Map `checked` to `state: complete/incomplete` instead of a `checked` field

## Problem
Updating checklist items via the MCP tool failed because the old endpoint/payload did not match Trello's API.

## Test plan
- [ ] Call `update_checkitem` on an existing checkitem with `checked: true`
- [ ] Verify the item shows as complete in Trello
- [ ] Call again with `checked: false` and verify it toggles back